### PR TITLE
Fix eslint flat config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ module.exports = defineConfig({
 ```ts
 // @ts-check
 const { defineFlatConfig } = require('eslint-define-config');
+const customConfig = require('./custom-config.js')
+const js = require('@eslint/js')
 
 /// <reference types="@eslint-types/typescript-eslint" />
 
 module.exports = defineFlatConfig([
-  'eslint:recommended',
+  customConfig,
+  js,
   {
     plugins: {
       // plugins...

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ module.exports = defineConfig({
 ```ts
 // @ts-check
 const { defineFlatConfig } = require('eslint-define-config');
-const js = require('@eslint/js')
-const customConfig = require('./custom-config.js')
+const js = require('@eslint/js');
+const customConfig = require('./custom-config.js');
 
 /// <reference types="@eslint-types/typescript-eslint" />
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ module.exports = defineConfig({
 ```ts
 // @ts-check
 const { defineFlatConfig } = require('eslint-define-config');
-const customConfig = require('./custom-config.js')
 const js = require('@eslint/js')
+const customConfig = require('./custom-config.js')
 
 /// <reference types="@eslint-types/typescript-eslint" />
 
 module.exports = defineFlatConfig([
+  js.configs.recommended,
   customConfig,
-  js,
   {
     plugins: {
       // plugins...


### PR DESCRIPTION
When you try to run the config, the code doesn't work and typescript starts to yell at you. The solution was to take out 'eslint:recommended', which I changed to the example in the official eslint docs https://eslint.org/docs/latest/use/configure/migration-guide#predefined-and-shareable-configs.

This might seems small but I was stuck on this for a while until I was reading on the official docs and realized that using strings for config like this isn't possible. It's also defined in the ts file for defineFlatConfig so it seems counterintuitive to show an example that doesn't work.